### PR TITLE
install the dict files in the same directory as the model files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr
 DATADIR ?= $(PREFIX)/share
 DESTDIR ?=
-
+MODELDIR ?= $(DESTDIR)$(DATADIR)/akaza/model/default/
 
 all: data/bigram.model \
 	 data/bigram.model \
@@ -140,9 +140,9 @@ evaluate: data/bigram.model
 # -------------------------------------------------------------------------
 
 install:
-	install -m 0755 -d $(DESTDIR)$(DATADIR)/akaza/model/default/
-	install -m 0644 data/*.model $(DESTDIR)$(DATADIR)/akaza/model/default/
-	install -m 0644 data/SKK-JISYO.* $(DESTDIR)$(DATADIR)/akaza/dict/
+	install -m 0755 -d $(MODELDIR)
+	install -m 0644 data/*.model $(MODELDIR)
+	install -m 0644 data/SKK-JISYO.* $(MODELDIR)
 
 # -------------------------------------------------------------------------
 


### PR DESCRIPTION
https://github.com/akaza-im/akaza/blob/d4697b3361ae5aa596bb1e54eb8767848237deb8/libakaza/src/engine/bigram_word_viterbi_engine.rs#L94

からすると、辞書ファイルのインストール先ディレクトリはモデルファイルのインストール先ディレクトリと同じことが期待されているようなので、そのように変更します。